### PR TITLE
Avoid docker builds with every push and avoids duplicated workflows

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types:
       - closed
+  push:
+    tags:
+      - v*
 
 env:
   IMAGE_NAME: escape-datascience-school2022

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,7 +1,11 @@
 name: Base env test
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - 'main'
 
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
* This was happening due to the detached CI workflows.
* And because I forgot to add on: push: types: - tags on the CI file